### PR TITLE
SCP-7 pyvips 2.2.1, updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ libvips is required to be installed on your machine in order to install skylab-s
 
 - [Libvips documentation](https://www.libvips.org/install.html)
 
+pyvips v2.2.1 is required. If you encounter trouble installing pyvips == 2.2.1, for the time being you can use a conda environment and install pyvips there.
+
+```bash
+$ conda install --channel conda-forge pyvips
+```
+
 ## Installation
 
 ```bash

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('README.md') as fp:
 
 setup(
     name='skylab_studio',
-    version='0.0.14',
+    version='0.0.15',
     author='skylabtech',
     author_email='info@skylabtech.ai',
     packages=find_packages(),
@@ -24,7 +24,7 @@ setup(
     test_suite="skylabtech.test",
     install_requires=[
         "aiohttp >= 3.9.3",
-        "pyvips==2.0.2",
+        "pyvips == 2.2.1",
         "requests >= 2.0.0"
     ],
     extras_require={
@@ -34,7 +34,7 @@ setup(
             "requests_mock >= 1.5.2",
         ]
     },
-    
+
     classifiers=[
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",

--- a/skylab_studio/version.py
+++ b/skylab_studio/version.py
@@ -3,4 +3,4 @@ SkylabStudio - Python Client
 For more information, visit https://studio.skylabtech.ai
 """
 
-VERSION = '0.0.14'
+VERSION = '0.0.15'


### PR DESCRIPTION
Updated setup.py to use pyvips 2.2.1 since its actually obtainable with conda. Waiting to see if pull: https://github.com/libvips/pyvips/pull/445 will fix the process of installing > 2.2.1. 